### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -1,4 +1,6 @@
 name: Build and Test PR
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/codeacula/rydia/security/code-scanning/1](https://github.com/codeacula/rydia/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` key to the workflow to explicitly declare the minimum required privileges for the GITHUB_TOKEN. This should be placed at the root level (under the `name` line and before or after `on:`) or inside the job definition (under `build-and-test:`), but root level is preferred for maximum clarity and coverage. Based on the workflow contents, only read permission for repository contents is required (`contents: read`). No other permissions (write or access to other resources) are necessary. Therefore, edit `.github/workflows/pr-build-test.yml` and add:

```
permissions:
  contents: read
```

directly after the `name` line for transparency and maintainability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
